### PR TITLE
Generate install scripts for system packages

### DIFF
--- a/src/rsysreqs/cmd/rsysreqs-server/main.go
+++ b/src/rsysreqs/cmd/rsysreqs-server/main.go
@@ -101,7 +101,7 @@ func getPackages(c *gin.Context) {
 	installScripts := generator.InstallScripts(packages)
 
 	c.JSON(http.StatusOK, gin.H{
-		"packages":       packages,
-		"installScripts": installScripts,
+		"packages":        packages,
+		"install_scripts": installScripts,
 	})
 }

--- a/src/rsysreqs/cmd/rsysreqs-server/main.go
+++ b/src/rsysreqs/cmd/rsysreqs-server/main.go
@@ -90,13 +90,15 @@ func getPackages(c *gin.Context) {
 		return
 	}
 
-	installScripts, err := scripts.GenerateInstallScripts(system, packages)
+	generator, err := scripts.NewScriptGenerator(system)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": err.Error(),
 		})
 		return
 	}
+
+	installScripts := generator.InstallScripts(packages)
 
 	c.JSON(http.StatusOK, gin.H{
 		"packages":       packages,

--- a/src/rsysreqs/cmd/rsysreqs-server/main.go
+++ b/src/rsysreqs/cmd/rsysreqs-server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"rsysreqs/rules"
+	"rsysreqs/scripts"
 )
 
 var ErrMissingParams = errors.New("missing required parameters")
@@ -89,7 +90,16 @@ func getPackages(c *gin.Context) {
 		return
 	}
 
+	installScripts, err := scripts.GenerateInstallScripts(system, packages)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
-		"packages": packages,
+		"packages":       packages,
+		"installScripts": installScripts,
 	})
 }

--- a/src/rsysreqs/cmd/rsysreqs/main.go
+++ b/src/rsysreqs/cmd/rsysreqs/main.go
@@ -50,11 +50,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	installScripts, err := scripts.GenerateInstallScripts(system, packages)
+	generator, err := scripts.NewScriptGenerator(system)
 	if err != nil {
-		fmt.Println("error generating install scripts", err)
+		fmt.Println("error generating install scripts:", err)
 		os.Exit(1)
 	}
+
+	installScripts := generator.InstallScripts(packages)
 
 	pkgActions := struct {
 		Packages       []string `json:"packages"`

--- a/src/rsysreqs/cmd/rsysreqs/main.go
+++ b/src/rsysreqs/cmd/rsysreqs/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 
-	"encoding/json"
-
 	"rsysreqs/rules"
+	"rsysreqs/scripts"
 )
 
 func main() {
@@ -50,10 +50,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	packagesJson, err := json.MarshalIndent(packages, "", "  ")
+	installScripts, err := scripts.GenerateInstallScripts(system, packages)
+	if err != nil {
+		fmt.Println("error generating install scripts", err)
+		os.Exit(1)
+	}
+
+	pkgActions := struct {
+		Packages       []string `json:"packages"`
+		InstallScripts []string `json:"installScripts"`
+	}{
+		packages,
+		installScripts,
+	}
+
+	pkgActionsJson, err := json.MarshalIndent(pkgActions, "", "  ")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	fmt.Printf("%s\n", packagesJson)
+	fmt.Printf("%s\n", pkgActionsJson)
 }

--- a/src/rsysreqs/cmd/rsysreqs/main.go
+++ b/src/rsysreqs/cmd/rsysreqs/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	pkgActions := struct {
 		Packages       []string `json:"packages"`
-		InstallScripts []string `json:"installScripts"`
+		InstallScripts []string `json:"install_scripts"`
 	}{
 		packages,
 		installScripts,

--- a/src/rsysreqs/scripts/scripts.go
+++ b/src/rsysreqs/scripts/scripts.go
@@ -1,0 +1,41 @@
+package scripts
+
+import (
+	"errors"
+	"fmt"
+
+	"rsysreqs/rules"
+)
+
+var ErrUnsupportedSystem = errors.New("unsupported system")
+
+func GenerateInstallScripts(sys rules.System, packages []string) ([]string, error) {
+	var cmds []string
+	for _, pkg := range packages {
+		cmd, err := generateInstallScript(sys, pkg)
+		if err != nil {
+			return nil, err
+		}
+		cmds = append(cmds, cmd)
+	}
+
+	return cmds, nil
+}
+
+func generateInstallScript(sys rules.System, pkg string) (string, error) {
+	var script string
+	switch {
+	case sys.Os == "linux" && sys.Distribution == "ubuntu":
+		script = ubuntuInstallScript(pkg)
+	}
+
+	if script == "" {
+		return "", ErrUnsupportedSystem
+	}
+
+	return script, nil
+}
+
+func ubuntuInstallScript(pkg string) string {
+	return fmt.Sprintf("apt-get install -y %s", pkg)
+}

--- a/src/rsysreqs/scripts/scripts.go
+++ b/src/rsysreqs/scripts/scripts.go
@@ -2,40 +2,20 @@ package scripts
 
 import (
 	"errors"
-	"fmt"
 
 	"rsysreqs/rules"
 )
 
 var ErrUnsupportedSystem = errors.New("unsupported system")
 
-func GenerateInstallScripts(sys rules.System, packages []string) ([]string, error) {
-	var cmds []string
-	for _, pkg := range packages {
-		cmd, err := generateInstallScript(sys, pkg)
-		if err != nil {
-			return nil, err
-		}
-		cmds = append(cmds, cmd)
-	}
-
-	return cmds, nil
+type ScriptGenerator interface {
+	InstallScripts(packages []string) []string
 }
 
-func generateInstallScript(sys rules.System, pkg string) (string, error) {
-	var script string
+func NewScriptGenerator(sys rules.System) (ScriptGenerator, error) {
 	switch {
 	case sys.Os == "linux" && sys.Distribution == "ubuntu":
-		script = ubuntuInstallScript(pkg)
+		return ubuntuScriptGenerator{}, nil
 	}
-
-	if script == "" {
-		return "", ErrUnsupportedSystem
-	}
-
-	return script, nil
-}
-
-func ubuntuInstallScript(pkg string) string {
-	return fmt.Sprintf("apt-get install -y %s", pkg)
+	return nil, ErrUnsupportedSystem
 }

--- a/src/rsysreqs/scripts/scripts_test.go
+++ b/src/rsysreqs/scripts/scripts_test.go
@@ -1,0 +1,34 @@
+package scripts
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"rsysreqs/rules"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type Suite struct{}
+
+var _ = check.Suite(&Suite{})
+
+func (s *Suite) TestGenerateInstallScripts(c *check.C) {
+	sys := rules.System{Os: "linux", Distribution: "ubuntu"}
+	packages := []string{"pkgA", "pkgB"}
+	scripts, err := GenerateInstallScripts(sys, packages)
+
+	c.Assert(err, check.IsNil)
+	c.Assert(scripts, check.HasLen, 2)
+	c.Assert(scripts[0], check.DeepEquals, "apt-get install -y pkgA")
+	c.Assert(scripts[1], check.DeepEquals, "apt-get install -y pkgB")
+}
+
+func (s *Suite) TestGenerateInstallScript(c *check.C) {
+	sys := rules.System{Os: "linux", Distribution: "ubuntu"}
+	script, err := generateInstallScript(sys, "pkgA")
+
+	c.Assert(err, check.IsNil)
+	c.Assert(script, check.Equals, "apt-get install -y pkgA")
+}

--- a/src/rsysreqs/scripts/scripts_test.go
+++ b/src/rsysreqs/scripts/scripts_test.go
@@ -14,21 +14,16 @@ type Suite struct{}
 
 var _ = check.Suite(&Suite{})
 
-func (s *Suite) TestGenerateInstallScripts(c *check.C) {
+func (s *Suite) TestNewScriptGenerator(c *check.C) {
 	sys := rules.System{Os: "linux", Distribution: "ubuntu"}
-	packages := []string{"pkgA", "pkgB"}
-	scripts, err := GenerateInstallScripts(sys, packages)
-
+	generator, err := NewScriptGenerator(sys)
 	c.Assert(err, check.IsNil)
-	c.Assert(scripts, check.HasLen, 2)
-	c.Assert(scripts[0], check.DeepEquals, "apt-get install -y pkgA")
-	c.Assert(scripts[1], check.DeepEquals, "apt-get install -y pkgB")
+	c.Assert(generator, check.FitsTypeOf, ubuntuScriptGenerator{})
 }
 
-func (s *Suite) TestGenerateInstallScript(c *check.C) {
-	sys := rules.System{Os: "linux", Distribution: "ubuntu"}
-	script, err := generateInstallScript(sys, "pkgA")
-
-	c.Assert(err, check.IsNil)
-	c.Assert(script, check.Equals, "apt-get install -y pkgA")
+func (s *Suite) TestNewScriptGeneratorUnsupported(c *check.C) {
+	sys := rules.System{Os: "unsupported_os"}
+	generator, err := NewScriptGenerator(sys)
+	c.Assert(err, check.Equals, ErrUnsupportedSystem)
+	c.Assert(generator, check.IsNil)
 }

--- a/src/rsysreqs/scripts/scripts_ubuntu.go
+++ b/src/rsysreqs/scripts/scripts_ubuntu.go
@@ -1,0 +1,14 @@
+package scripts
+
+import "fmt"
+
+type ubuntuScriptGenerator struct{}
+
+func (g ubuntuScriptGenerator) InstallScripts(packages []string) []string {
+	var scripts []string
+	for _, pkg := range packages {
+		script := fmt.Sprintf("apt-get install -y %s", pkg)
+		scripts = append(scripts, script)
+	}
+	return scripts
+}

--- a/src/rsysreqs/scripts/scripts_ubuntu_test.go
+++ b/src/rsysreqs/scripts/scripts_ubuntu_test.go
@@ -1,0 +1,14 @@
+package scripts
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *Suite) TestUbuntuInstallScripts(c *check.C) {
+	generator := ubuntuScriptGenerator{}
+	scripts := generator.InstallScripts([]string{"pkgA", "pkgB"})
+	c.Assert(scripts, check.DeepEquals, []string{
+		"apt-get install -y pkgA",
+		"apt-get install -y pkgB",
+	})
+}


### PR DESCRIPTION
Only supports Ubuntu for now. More specifically, Ubuntu 16, but it seems like all releases use the same `apt-get install` command.

Examples:
```sh
$ rsysreqs -d ~/rsysreqs-db/rules -s "libxml2, libcurl" -os linux -dist ubuntu
{
  "packages": [
    "libcurl4-openssl-dev",
    "libxml2-dev"
  ],
  "install_scripts": [
    "apt-get install -y libcurl4-openssl-dev",
    "apt-get install -y libxml2-dev"
  ]
}
```

```json
GET /packages?sysreqs="libxml2, libcurl"&os=linux&dist=ubuntu
{
    "install_scripts": [
        "apt-get install -y libcurl4-openssl-dev",
        "apt-get install -y libxml2-dev"
    ],
    "packages": [
        "libcurl4-openssl-dev",
        "libxml2-dev"
    ]
}
```